### PR TITLE
Fix path separator

### DIFF
--- a/application/config.go
+++ b/application/config.go
@@ -7,7 +7,7 @@ import (
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"runtime"
 	"time"
 )
@@ -60,9 +60,9 @@ type Job struct {
 func init() {
 	Config = &Configuration{
 		Server: &Server{
-			WorkDir:      path.Join(os.TempDir(), Name),
+			WorkDir:      filepath.Join(os.TempDir(), Name),
 			Port:         8080,
-			DatabasePath: path.Join(os.Getenv("HOME"), ".duci/db"),
+			DatabasePath: filepath.Join(os.Getenv("HOME"), ".duci/db"),
 		},
 		GitHub: &GitHub{
 			SSHKeyPath: "",

--- a/application/service/git/git_test.go
+++ b/application/service/git/git_test.go
@@ -17,7 +17,7 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
 	"net/url"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 )
 
@@ -72,7 +72,7 @@ func TestSshGitService_Clone(t *testing.T) {
 	t.Run("when success git clone", func(t *testing.T) {
 		// setup
 		dirStr := fmt.Sprintf("duci_test_%s", random.String(16, random.Alphanumeric))
-		tempDir := path.Join(os.TempDir(), dirStr)
+		tempDir := filepath.Join(os.TempDir(), dirStr)
 		if err := os.MkdirAll(tempDir, 0700); err != nil {
 			t.Fatalf("%+v", err)
 		}
@@ -124,7 +124,7 @@ func TestSshGitService_Clone(t *testing.T) {
 	t.Run("when failure git checkout", func(t *testing.T) {
 		// setup
 		dirStr := fmt.Sprintf("duci_test_%s", random.String(16, random.Alphanumeric))
-		tempDir := path.Join(os.TempDir(), dirStr)
+		tempDir := filepath.Join(os.TempDir(), dirStr)
 		if err := os.MkdirAll(tempDir, 0700); err != nil {
 			t.Fatalf("%+v", err)
 		}
@@ -193,7 +193,7 @@ func TestHttpGitService_Clone(t *testing.T) {
 	t.Run("when success git clone", func(t *testing.T) {
 		// setup
 		dirStr := fmt.Sprintf("duci_test_%s", random.String(16, random.Alphanumeric))
-		tempDir := path.Join(os.TempDir(), dirStr)
+		tempDir := filepath.Join(os.TempDir(), dirStr)
 		if err := os.MkdirAll(tempDir, 0700); err != nil {
 			t.Fatalf("%+v", err)
 		}
@@ -245,7 +245,7 @@ func TestHttpGitService_Clone(t *testing.T) {
 	t.Run("when failure git checkout", func(t *testing.T) {
 		// setup
 		dirStr := fmt.Sprintf("duci_test_%s", random.String(16, random.Alphanumeric))
-		tempDir := path.Join(os.TempDir(), dirStr)
+		tempDir := filepath.Join(os.TempDir(), dirStr)
 		if err := os.MkdirAll(tempDir, 0700); err != nil {
 			t.Fatalf("%+v", err)
 		}
@@ -297,11 +297,11 @@ func createTemporaryKey(t *testing.T) string {
 	}
 	privateKeyPem := string(pem.EncodeToMemory(&privateKeyBlock))
 
-	tempDir := path.Join(os.TempDir(), random.String(16, random.Alphanumeric))
+	tempDir := filepath.Join(os.TempDir(), random.String(16, random.Alphanumeric))
 	if err := os.MkdirAll(tempDir, 0700); err != nil {
 		t.Fatalf("error occur: %+v", err)
 	}
-	keyPath := path.Join(tempDir, "id_rsa")
+	keyPath := filepath.Join(tempDir, "id_rsa")
 	file, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
 		t.Fatalf("error occur: %+v", err)

--- a/application/service/runner/runner.go
+++ b/application/service/runner/runner.go
@@ -18,7 +18,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 )
 
 // ErrFailure is a error describes task failure.
@@ -67,7 +67,7 @@ func (r *DockerRunner) Run(ctx context.Context, src *github.TargetSource, comman
 }
 
 func (r *DockerRunner) run(ctx context.Context, src *github.TargetSource, command ...string) error {
-	workDir := path.Join(r.BaseWorkDir, random.String(36, random.Alphanumeric))
+	workDir := filepath.Join(r.BaseWorkDir, random.String(36, random.Alphanumeric))
 
 	if err := r.Git.Clone(ctx, workDir, src); err != nil {
 		return errors.WithStack(err)
@@ -117,7 +117,7 @@ func (r *DockerRunner) dockerBuild(ctx context.Context, dir string, repo github.
 }
 
 func createTarball(workDir string) (*os.File, error) {
-	tarFilePath := path.Join(workDir, "duci.tar")
+	tarFilePath := filepath.Join(workDir, "duci.tar")
 	writeFile, err := os.OpenFile(tarFilePath, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -134,7 +134,7 @@ func createTarball(workDir string) (*os.File, error) {
 
 func dockerfilePath(workDir string) docker.Dockerfile {
 	dockerfile := "./Dockerfile"
-	if exists(path.Join(workDir, ".duci/Dockerfile")) {
+	if exists(filepath.Join(workDir, ".duci/Dockerfile")) {
 		dockerfile = ".duci/Dockerfile"
 	}
 	return docker.Dockerfile(dockerfile)
@@ -160,10 +160,10 @@ func (r *DockerRunner) dockerRun(ctx context.Context, dir string, repo github.Re
 func runtimeOpts(workDir string) (docker.RuntimeOptions, error) {
 	var opts docker.RuntimeOptions
 
-	if !exists(path.Join(workDir, ".duci/config.yml")) {
+	if !exists(filepath.Join(workDir, ".duci/config.yml")) {
 		return opts, nil
 	}
-	content, err := ioutil.ReadFile(path.Join(workDir, ".duci/config.yml"))
+	content, err := ioutil.ReadFile(filepath.Join(workDir, ".duci/config.yml"))
 	if err != nil {
 		return opts, errors.WithStack(err)
 	}

--- a/application/service/runner/runner_test.go
+++ b/application/service/runner/runner_test.go
@@ -16,7 +16,7 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"net/url"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -42,7 +42,7 @@ func TestRunnerImpl_Run_Normal(t *testing.T) {
 						return err
 					}
 
-					dockerfile, err := os.OpenFile(path.Join(dir, "Dockerfile"), os.O_RDWR|os.O_CREATE, 0600)
+					dockerfile, err := os.OpenFile(filepath.Join(dir, "Dockerfile"), os.O_RDWR|os.O_CREATE, 0600)
 					if err != nil {
 						return err
 					}
@@ -91,7 +91,7 @@ func TestRunnerImpl_Run_Normal(t *testing.T) {
 				Return(nil)
 
 			r := &runner.DockerRunner{
-				BaseWorkDir: path.Join(os.TempDir(), "test-runner"),
+				BaseWorkDir: filepath.Join(os.TempDir(), "test-runner"),
 				Git:         mockGit,
 				GitHub:      mockGitHub,
 				Docker:      mockDocker,
@@ -126,11 +126,11 @@ func TestRunnerImpl_Run_Normal(t *testing.T) {
 			mockGit.EXPECT().Clone(gomock.Any(), gomock.Any(), gomock.Any()).
 				Times(1).
 				DoAndReturn(func(_ interface{}, dir string, _ interface{}) error {
-					if err := os.MkdirAll(path.Join(dir, ".duci"), 0700); err != nil {
+					if err := os.MkdirAll(filepath.Join(dir, ".duci"), 0700); err != nil {
 						return err
 					}
 
-					dockerfile, err := os.OpenFile(path.Join(dir, ".duci/Dockerfile"), os.O_RDWR|os.O_CREATE, 0600)
+					dockerfile, err := os.OpenFile(filepath.Join(dir, ".duci/Dockerfile"), os.O_RDWR|os.O_CREATE, 0600)
 					if err != nil {
 						return err
 					}
@@ -178,7 +178,7 @@ func TestRunnerImpl_Run_Normal(t *testing.T) {
 				Return(nil)
 
 			r := &runner.DockerRunner{
-				BaseWorkDir: path.Join(os.TempDir(), "test-runner"),
+				BaseWorkDir: filepath.Join(os.TempDir(), "test-runner"),
 				Git:         mockGit,
 				GitHub:      mockGitHub,
 				Docker:      mockDocker,
@@ -214,11 +214,11 @@ func TestRunnerImpl_Run_Normal(t *testing.T) {
 		mockGit.EXPECT().Clone(gomock.Any(), gomock.Any(), gomock.Any()).
 			Times(1).
 			DoAndReturn(func(_ interface{}, dir string, _ interface{}) error {
-				if err := os.MkdirAll(path.Join(dir, ".duci"), 0700); err != nil {
+				if err := os.MkdirAll(filepath.Join(dir, ".duci"), 0700); err != nil {
 					return err
 				}
 
-				dockerfile, err := os.OpenFile(path.Join(dir, ".duci/config.yml"), os.O_RDWR|os.O_CREATE, 0600)
+				dockerfile, err := os.OpenFile(filepath.Join(dir, ".duci/config.yml"), os.O_RDWR|os.O_CREATE, 0600)
 				if err != nil {
 					return err
 				}
@@ -266,7 +266,7 @@ func TestRunnerImpl_Run_Normal(t *testing.T) {
 			Return(nil)
 
 		r := &runner.DockerRunner{
-			BaseWorkDir: path.Join(os.TempDir(), "test-runner"),
+			BaseWorkDir: filepath.Join(os.TempDir(), "test-runner"),
 			Git:         mockGit,
 			GitHub:      mockGitHub,
 			Docker:      mockDocker,
@@ -340,7 +340,7 @@ func TestRunnerImpl_Run_NonNormal(t *testing.T) {
 			Return(nil)
 
 		r := &runner.DockerRunner{
-			BaseWorkDir: path.Join(os.TempDir(), "test-runner"),
+			BaseWorkDir: filepath.Join(os.TempDir(), "test-runner"),
 			Git:         mockGit,
 			GitHub:      mockGitHub,
 			Docker:      mockDocker,
@@ -378,7 +378,7 @@ func TestRunnerImpl_Run_NonNormal(t *testing.T) {
 			Return(errors.New("test error"))
 
 		r := &runner.DockerRunner{
-			BaseWorkDir: path.Join(os.TempDir(), "test-runner"),
+			BaseWorkDir: filepath.Join(os.TempDir(), "test-runner"),
 			GitHub:      mockGitHub,
 			LogStore:    mockLogStore,
 		}
@@ -515,7 +515,7 @@ func TestRunnerImpl_Run_NonNormal(t *testing.T) {
 			Return(nil)
 
 		r := &runner.DockerRunner{
-			BaseWorkDir: path.Join(os.TempDir(), "test-runner"),
+			BaseWorkDir: filepath.Join(os.TempDir(), "test-runner"),
 			Git:         mockGit,
 			GitHub:      mockGitHub,
 			Docker:      mockDocker,
@@ -586,7 +586,7 @@ func TestRunnerImpl_Run_NonNormal(t *testing.T) {
 			Return(nil)
 
 		r := &runner.DockerRunner{
-			BaseWorkDir: path.Join(os.TempDir(), "test-runner"),
+			BaseWorkDir: filepath.Join(os.TempDir(), "test-runner"),
 			Git:         mockGit,
 			GitHub:      mockGitHub,
 			Docker:      mockDocker,
@@ -659,7 +659,7 @@ func TestRunnerImpl_Run_NonNormal(t *testing.T) {
 			Return(nil)
 
 		r := &runner.DockerRunner{
-			BaseWorkDir: path.Join(os.TempDir(), "test-runner"),
+			BaseWorkDir: filepath.Join(os.TempDir(), "test-runner"),
 			Git:         mockGit,
 			GitHub:      mockGitHub,
 			Docker:      mockDocker,
@@ -730,7 +730,7 @@ func TestRunnerImpl_Run_NonNormal(t *testing.T) {
 			Return(nil)
 
 		r := &runner.DockerRunner{
-			BaseWorkDir: path.Join(os.TempDir(), "test-runner"),
+			BaseWorkDir: filepath.Join(os.TempDir(), "test-runner"),
 			Git:         mockGit,
 			GitHub:      mockGitHub,
 			Docker:      mockDocker,
@@ -806,7 +806,7 @@ func TestRunnerImpl_Run_NonNormal(t *testing.T) {
 			Return(nil)
 
 		r := &runner.DockerRunner{
-			BaseWorkDir: path.Join(os.TempDir(), "test-runner"),
+			BaseWorkDir: filepath.Join(os.TempDir(), "test-runner"),
 			Git:         mockGit,
 			GitHub:      mockGitHub,
 			Docker:      mockDocker,
@@ -835,7 +835,7 @@ func cloneSuccess(_ interface{}, dir string, _ interface{}) error {
 		return err
 	}
 
-	dockerfile, err := os.OpenFile(path.Join(dir, "Dockerfile"), os.O_RDWR|os.O_CREATE, 0600)
+	dockerfile, err := os.OpenFile(filepath.Join(dir, "Dockerfile"), os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		return err
 	}

--- a/infrastructure/archive/tar/tar.go
+++ b/infrastructure/archive/tar/tar.go
@@ -57,7 +57,7 @@ func newContent(path string, dir string) (*content, error) {
 	}
 
 	header := &tar.Header{
-		Name: strings.Replace(file.Name(), dir+"/", "", -1),
+		Name: strings.Replace(file.Name(), dir+string(os.PathSeparator), "", -1),
 		Mode: 0600,
 		Size: int64(len(data)),
 	}

--- a/infrastructure/archive/tar/tar_test.go
+++ b/infrastructure/archive/tar/tar_test.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -20,16 +20,16 @@ func TestCreate(t *testing.T) {
 		testDir := createTestDir(t)
 
 		// given
-		archiveDir := path.Join(testDir, "archive")
+		archiveDir := filepath.Join(testDir, "archive")
 
-		createFile(t, path.Join(archiveDir, "file"), "this is file.", 0400)
-		createFile(t, path.Join(archiveDir, "dir", "file"), "this is file in the dir.", 0400)
+		createFile(t, filepath.Join(archiveDir, "file"), "this is file.", 0400)
+		createFile(t, filepath.Join(archiveDir, "dir", "file"), "this is file in the dir.", 0400)
 
-		if err := os.MkdirAll(path.Join(archiveDir, "empty"), 0700); err != nil {
+		if err := os.MkdirAll(filepath.Join(archiveDir, "empty"), 0700); err != nil {
 			t.Fatalf("%+v", err)
 		}
 
-		output := path.Join(testDir, "output.tar")
+		output := filepath.Join(testDir, "output.tar")
 		tarFile, err := os.OpenFile(output, os.O_RDWR|os.O_CREATE, 0400)
 		if err != nil {
 			t.Fatalf("%+v", err)
@@ -39,7 +39,7 @@ func TestCreate(t *testing.T) {
 		// and
 		expected := Files{
 			{
-				Name:    "dir/file",
+				Name:    filepath.Join("dir", "file"),
 				Content: "this is file in the dir.",
 			},
 			{
@@ -68,7 +68,7 @@ func TestCreate(t *testing.T) {
 		testDir := createTestDir(t)
 
 		// given
-		output := path.Join(testDir, "output.tar")
+		output := filepath.Join(testDir, "output.tar")
 		tarFile, err := os.OpenFile(output, os.O_RDWR|os.O_CREATE, 0400)
 		if err != nil {
 			t.Fatalf("%+v", err)
@@ -89,11 +89,11 @@ func TestCreate(t *testing.T) {
 		testDir := createTestDir(t)
 
 		// given
-		archiveDir := path.Join(testDir, "archive")
+		archiveDir := filepath.Join(testDir, "archive")
 
-		createFile(t, path.Join(archiveDir, "file"), "this is file.", 0400)
+		createFile(t, filepath.Join(archiveDir, "file"), "this is file.", 0400)
 
-		output := path.Join(testDir, "output.tar")
+		output := filepath.Join(testDir, "output.tar")
 		tarFile, err := os.OpenFile(output, os.O_RDWR|os.O_CREATE, 0400)
 		if err != nil {
 			t.Fatalf("%+v", err)
@@ -118,11 +118,11 @@ func TestCreate(t *testing.T) {
 		testDir := createTestDir(t)
 
 		// given
-		archiveDir := path.Join(testDir, "archive")
+		archiveDir := filepath.Join(testDir, "archive")
 
-		createFile(t, path.Join(archiveDir, "file"), "this is file.", 0000)
+		createFile(t, filepath.Join(archiveDir, "file"), "this is file.", 0000)
 
-		output := path.Join(testDir, "output.tar")
+		output := filepath.Join(testDir, "output.tar")
 		tarFile, err := os.OpenFile(output, os.O_RDWR|os.O_CREATE, 0400)
 		if err != nil {
 			t.Fatalf("%+v", err)
@@ -176,8 +176,8 @@ func readTarArchive(t *testing.T, output string) Files {
 func createTestDir(t *testing.T) string {
 	t.Helper()
 
-	tempDir := path.Join(os.TempDir(), fmt.Sprintf("duci_test_%v", time.Now().Unix()))
-	if err := os.MkdirAll(path.Join(tempDir, "dir"), 0700); err != nil {
+	tempDir := filepath.Join(os.TempDir(), fmt.Sprintf("duci_test_%v", time.Now().Unix()))
+	if err := os.MkdirAll(filepath.Join(tempDir, "dir"), 0700); err != nil {
 		t.Fatalf("%+v", err)
 	}
 
@@ -187,8 +187,8 @@ func createTestDir(t *testing.T) string {
 func createFile(t *testing.T, name string, content string, perm os.FileMode) {
 	t.Helper()
 
-	paths := strings.Split(name, "/")
-	dir := strings.Join(paths[:len(paths)-1], "/")
+	paths := strings.Split(name, string(os.PathSeparator))
+	dir := strings.Join(paths[:len(paths)-1], string(os.PathSeparator))
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		t.Fatalf("%+v", err)
 	}


### PR DESCRIPTION
For windows, 
- Use `fpath/filepath.Join` instead of `path.Join`.
- Use separator `os.PathSeparator` insetead of `/`.