### PR TITLE
Tuning CI configuration

### DIFF
--- a/.duci/Dockerfile
+++ b/.duci/Dockerfile
@@ -5,12 +5,14 @@ RUN apk --update add --no-cache alpine-sdk
 
 WORKDIR /go/src/github.com/duck8823/duci
 
-ADD . .
-
-ENV CC=gcc
-ENV CI=duci
-
 ENV GO111MODULE=on
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
+COPY . .
 
 ENTRYPOINT ["make"]
 CMD ["test"]

--- a/.duci/Dockerfile
+++ b/.duci/Dockerfile
@@ -3,9 +3,7 @@ MAINTAINER shunsuke maeda <duck8823@gmail.com>
 
 RUN apk --update add --no-cache alpine-sdk
 
-WORKDIR /go/src/github.com/duck8823/duci
-
-ENV GO111MODULE=on
+WORKDIR /workdir
 
 COPY go.mod .
 COPY go.sum .

--- a/.duci/config.yml
+++ b/.duci/config.yml
@@ -1,3 +1,0 @@
----
-volumes:
-  - ${GOPATH}/pkg/mod/cache:/go/pkg/mod/cache

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,4 +1,4 @@
-workflow "test" {
+workflow "main workflow" {
   on = "push"
   resolves = ["test"]
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,8 +1,10 @@
 workflow "test" {
   on = "push"
-  resolves = ["duci"]
+  resolves = ["test"]
 }
 
-action "duci" {
-  uses = "./.duci/"
+action "test" {
+  uses = "docker://golang:1.11"
+  runs = "go"
+  args = ["test", "./..."]
 }

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ test:
 test-in-docker:
 	docker build -t duck8823/duci:test -f .duci/Dockerfile .
 	docker run --rm \
-	           -v ${GOPATH}/pkg/mod/cache:/go/pkg/mod/cache \
 	           duck8823/duci:test test
 
 clean:


### PR DESCRIPTION
- Remove unnecessary environment
- Use COPY instead of ADD
- RUN go mod download for more faster using build cache